### PR TITLE
GCAM metadata schema for data products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ This repository includes metadata XML forms that build upon a schema provided by
 The following meatadata forms are now available for use:
 
 | Parent Software | Form Name |
-| -- | -- | -- |
-| GCAM | `gcam_metadata` |
+|:-:|:-:|
+| GCAM | `gcam_metadata.xml` |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# metadata
+
+Metadata forms for use by the GCIMS community
+
+## Description
+This repository includes metadata XML forms that build upon a schema provided by [DataCite.org](https://schema.datacite.org/meta/kernel-4.3/).  These metadata are to be included with any data product to abide by our commitment to FAIR guiding principles for scientific data management and stewardship [Wilkinson et al. 2016](https://www.nature.com/articles/sdata201618).  XML elements from DataCite templates are defined here:  [DataCite Documentaion](https://schema.datacite.org/meta/kernel-4.3/doc/DataCite-MetadataKernel_v4.3.pdf).
+
+## Contents
+The following meatadata forms are now available for use:
+
+| Parent Software | Form Name |
+| -- | -- | -- |
+| GCAM | `gcam_metadata` |

--- a/gcam_metadata.xml
+++ b/gcam_metadata.xml
@@ -63,9 +63,9 @@
   </descriptions>
   <fundingReferences>
     <fundingReference>
-      <funderName>National Science Foundation</funderName>
+      <funderName>US Department of Energy, Office of Science, as part of research in MultiSector Dynamics, Earth and Environmental System Modeling Program</funderName>
       <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/100000001</funderIdentifier>
-      <awardNumber>CBET-106</awardNumber>
+      <awardNumber>DE-AC05-76RL01830</awardNumber>
       <awardTitle>Full DataCite XML Example</awardTitle>
     </fundingReference>
   </fundingReferences>

--- a/gcam_metadata.xml
+++ b/gcam_metadata.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
+  <identifier identifierType="DOI">10.5072/example-full</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Person, I.M.</creatorName>
+      <givenName>I.M.</givenName>
+      <familyName>Person</familyName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0001-5000-0007</nameIdentifier>
+      <affiliation affiliationIdentifier="https://ror.org/04wxnsj81" affiliationIdentifierScheme="ROR">DataCite</affiliation>
+    </creator>
+    <creator>
+      <creatorName nameType="Organizational" xml:lang="en">Pacific Northwest National Laboratory</creatorName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en-US">Full DataCite XML Example</title>
+    <title xml:lang="en-US" titleType="Subtitle">Demonstration of DataCite Properties.</title>
+  </titles>
+  <publisher xml:lang="en">Pacific Northwest National Laboratory</publisher>
+  <publicationYear>2020</publicationYear>
+  <subjects>
+    <subject xml:lang="en-US" schemeURI="http://dewey.info/" subjectScheme="dewey">000 computer science</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="ProjectLeader">
+      <contributorName>Human, I.M.</contributorName>
+      <givenName>I.M.</givenName>
+      <familyName>Human</familyName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0002-7285-027X</nameIdentifier>
+      <affiliation affiliationIdentifier="https://ror.org/03yrm5c26" affiliationIdentifierScheme="ROR">University of Maryland</affiliation>
+    </contributor>
+    <contributor contributorType="Sponsor">
+      <contributorName xml:lang="en">University of Maryland</contributorName>
+    </contributor>
+    <contributor contributorType="Producer">
+      <contributorName xml:lang="en">Pacific Northwest National Laboratory</contributorName>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Updated" dateInformation="Updated with 4.3 properties">2020-06-02</date>
+  </dates>
+  <language>en-US</language>
+  <resourceType resourceTypeGeneral="Software">XML</resourceType>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="URL">https://schema.datacite.org/meta/kernel-4.3/example/datacite-example-full-v4.3.xml</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="HasMetadata" relatedMetadataScheme="citeproc+json" schemeURI="https://github.com/citation-style-language/schema/raw/master/csl-data.json">https://data.datacite.org/application/citeproc+json/10.5072/example-full</relatedIdentifier>
+  </relatedIdentifiers>
+  <sizes>
+    <size>4 kB</size>
+  </sizes>
+  <formats>
+    <format>application/xml</format>
+  </formats>
+  <version>4.3</version>
+  <rightsList>
+    <rights xml:lang="en-US" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC0 1.0" rightsURI="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rightsList>
+  <descriptions>
+    <description xml:lang="en-US" descriptionType="Abstract"> XML example of all DataCite Metadata Schema v4.3 properties. </description>
+  </descriptions>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>National Science Foundation</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/100000001</funderIdentifier>
+      <awardNumber>CBET-106</awardNumber>
+      <awardTitle>Full DataCite XML Example</awardTitle>
+    </fundingReference>
+  </fundingReferences>
+</resource>


### PR DESCRIPTION
Generate an v0 GCAM metadata form using DataCite as a template model.  We will need to create additional elements.

This metadata form will be able to be modified using a web interface via webform, or using a batch protocol that I will eventually build to generate a final metadata product users can download and include with their data products.

Right now, we need decide what has to be included in this form to gain an understanding of what elements, and their constraints, need to be included.

Resolves #1 